### PR TITLE
Fix: edit input lose focus when typing

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -109,7 +109,7 @@ export default {
     <ul class="task-list">
       <li
         v-for="taskItem in tasksInView"
-        :key="taskItem.label"
+        :key="taskItem.id"
         class="task-list-item"
       >
         <div class="task-list-checkbox-wrapper">


### PR DESCRIPTION
Issue : Edit input lose focus when typing a character

It's caused by the key on the v-for which should be more unique, I changed it to id